### PR TITLE
Updated package.json so that it uses the latest include-all version

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/balderdashy/sails-build-dictionary/issues"
   },
   "dependencies": {
-    "include-all": "~0.1.2",
+    "include-all": "~0.1.7",
     "lodash": "~2.4.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sails-build-dictionary",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Recursively build a dictionary of modules using include-all",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This is related to my latest change on include-all, so that you can pass a sortResult:true parameter, that can be used inside sails to make loadUserHooks, in lib/hooks/moduleloader/index.js sorted by name, allowing a rudimentary sort order based on folder names like 01-some-hook, 02-some-other-hook. Ugly but works
